### PR TITLE
Add actions for U, E, -, =, Q, and G

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,35 +17,46 @@ Get from [here](https://chrome.google.com/webstore/detail/lemmy-keyboard-navigat
 
 |                         Link Pages                                |
 |----------------------------------------------------------------------|
-| <kbd>J or ↓</kbd> = Next post                                |
-| <kbd>K or ↑</kbd> = Previous post                          |
-| <kbd>L or →</kbd> = Next page                  |
-| <kbd>H or ←</kbd> = Previous page                |
+| <kbd>J</kbd> or <kbd>↓</kbd> = Next Post                                |
+| <kbd>K</kbd> or <kbd>↑</kbd> = Previous Post                        |
+| <kbd>L</kbd> or <kbd>→</kbd> = Next Page                |
+| <kbd>H</kbd> or <kbd>←</kbd> = Previous Page                |
 | <kbd>A</kbd> = Upvote                                                |
+| <kbd>Z</kbd> = Downvote   |
 | <kbd>S</kbd> = Save Post                                               |
-| <kbd>Z</kbd> = Downvote                                              |
+| <kbd>E</kbd> = Edit Post                                               |
 | <kbd>X</kbd> = Expand/Collapse Post                                       |
-| <kbd>C</kbd> = View Comments (<kbd>⇧ Shift+C</kbd> to open in new tab)  |
-| <kbd>R</kbd> = Go to community (<kbd>⇧ Shift+R</kbd> to open in new tab)                                                 |
-| <kbd>⏎ Enter</kbd> = Visit Link (<kbd>⇧ Shift+⏎ Enter</kbd> to open in new tab)                                     |
+| <kbd>-</kbd> = Shrink Expanded Image                                       |
+| <kbd>=</kbd> = Grow Expanded Image                                       |
+| <kbd>G</kbd> = Open Navigation Dialog                                       |
+| <kbd>C</kbd> = View Comments (<kbd>⇧ Shift</kbd> + <kbd>C</kbd> to open in new tab)  |
+| <kbd>R</kbd> = Go to community (<kbd>⇧ Shift</kbd> + <kbd>R</kbd> to open in new tab)                                                 |
+| <kbd>U</kbd> = Go to poster's profile (<kbd>⇧ Shift</kbd> + <kbd>U</kbd> to open in new tab)                                                 |
+| <kbd>⏎ Enter</kbd> = Visit Link (<kbd>⇧ Shift</kbd> + <kbd>⏎ Enter</kbd> to open in new tab)                                     |
 
-![253778748-2f3671cc-c8e8-48d5-a69f-be3fc98a0fa9](https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/8668731/fc8ccf2a-f204-4897-82ef-0458509c1f83)
+![linkpages](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/239d3ecb-bec3-49d4-b987-bf69b7449607)
+
 
 
 
 |                         Comments                                 |
 |----------------------------------------------------------------------|
-| <kbd>J or ↓</kbd> = Next Comment                                 |
-| <kbd>K or ↑</kbd> = Previous Comment                           |
-| <kbd>L or →</kbd> = Next same-level Comment                    |
-| <kbd>H or ←</kbd> = Previous same-level Comment                |
+| <kbd>J</kbd> or <kbd>↓</kbd> = Next Comment                               |
+| <kbd>K</kbd> or <kbd>↑</kbd> = Previous Comment                       |
+| <kbd>L</kbd> or <kbd>→</kbd> = Next same-level Comment                |
+| <kbd>H</kbd> or <kbd>←</kbd> = Previous same-level Comment                |
+| <kbd>P</kbd> = Parent Comment                                               |
 | <kbd>A</kbd> = Upvote                                                |
 | <kbd>Z</kbd> = Downvote                                              |
 | <kbd>S</kbd> = Show more options / Save comment                                                |
+| <kbd>E</kbd> = Show more options / Edit comment                                                |
 | <kbd>R</kbd> = Reply                                                 |
-| <kbd>⏎ Enter or X</kbd> = Toggle collapse / Show more replies                                    |
+| <kbd>Q</kbd> = Show context                                                |
+| <kbd>G</kbd> = Open Navigation Dialog                                       |
+| <kbd>⏎ Enter</kbd> or <kbd>X</kbd> = Toggle collapse / Show more replies                                    |
+| <kbd>U</kbd> = Go to commenter's profile (<kbd>⇧ Shift</kbd> + <kbd>U</kbd> to open in new tab)                                                 |
 
-![253778862-2786b5a8-f8c2-434c-8fd4-e3d5b1fe0e83](https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/8668731/9f7191df-f9c0-4ef3-8528-79af781cd434)
+![comments](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/f2db918f-43b1-4cd3-9a77-643f77c3d9ca)
 
 
 ## Licence & Credits: 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Get from [here](https://chrome.google.com/webstore/detail/lemmy-keyboard-navigat
 |----------------------------------------------------------------------|
 | <kbd>J</kbd> or <kbd>↓</kbd> = Next Comment                               |
 | <kbd>K</kbd> or <kbd>↑</kbd> = Previous Comment                       |
-| <kbd>L</kbd> or <kbd>→</kbd> = Next same-level Comment                |
-| <kbd>H</kbd> or <kbd>←</kbd> = Previous same-level Comment                |
+| <kbd>⇧ Shift</kbd> + <kbd>J</kbd> or <kbd>L</kbd> or <kbd>→</kbd> = Next same-level Comment                |
+| <kbd>⇧ Shift</kbd> + <kbd>K</kbd> or <kbd>H</kbd> or <kbd>←</kbd> = Previous same-level Comment                |
 | <kbd>P</kbd> = Parent Comment                                               |
 | <kbd>A</kbd> = Upvote                                                |
 | <kbd>Z</kbd> = Downvote                                              |

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -219,7 +219,7 @@ function handleKeyPress(event) {
                 instanceanduser();
                 break;
             case contextKey:
-                getcontext();
+                getcontext(event);
                 break;
             case replycommKey:
                 if (window.location.pathname.includes("/post/")) {
@@ -232,7 +232,7 @@ function handleKeyPress(event) {
             }
             break;
             case userKey:
-                visituser();
+                visituser(event);
                 break;
             case openLinkandcollapseKey:
                 if (window.location.pathname.includes("/post/")) {
@@ -564,14 +564,13 @@ function community(event) {
         }
 }
 
-function visituser() {
-    var userbutton = currentEntry.getElementsByClassName("person-listing d-inline-flex align-items-baseline text-info")[0]
-    var userHREF = currentEntry.getElementsByClassName("person-listing d-inline-flex align-items-baseline text-info")[0].href
-
+function visituser(event) {
     if (event.shiftKey) {
-        window.open(userHREF)
+        window.open(
+            currentEntry.getElementsByClassName("person-listing d-inline-flex align-items-baseline text-info")[0].href,
+        );
     } else {
-        userbutton.click();
+        currentEntry.getElementsByClassName("person-listing d-inline-flex align-items-baseline text-info")[0].click();
     }
 }
 
@@ -585,15 +584,13 @@ function comments(event) {
     }
 }
 
-
-function getcontext() {
-    var contextbutton = currentEntry.querySelector('[title="Show context"]')
-    var contextHREF = currentEntry.querySelector('[title="Show context"]').href
-
+function getcontext(event) {
     if (event.shiftKey) {
-        window.open(contextHREF)
+        window.open(
+            currentEntry.getElementsByClassName("btn btn-link btn-animate text-muted btn-sm")[0].href,
+        );
     } else {
-        contextbutton.click();
+        contextbutton = currentEntry.getElementsByClassName("btn btn-link btn-animate text-muted btn-sm")[0].click();
     }
 }
 

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -11,7 +11,7 @@
 // @icon          https://raw.githubusercontent.com/vmavromatis/Lemmy-keyboard-navigation/main/icon.png?inline=true
 // @homepageURL   https://github.com/vmavromatis/Lemmy-keyboard-navigation
 // @namespace     https://github.com/vmavromatis/Lemmy-keyboard-navigation
-// @description   Easily navigate Lemmy with keyboard arrows
+// @description   Easily navigate Lemmy with your keyboard
 // @run-at        document-end
 // ==/UserScript==
 
@@ -19,13 +19,14 @@
 if (document.querySelectorAll('.lemmy-site').length >= 1){
 
 // Vim key toggle
-// Default: false
-// Set to true for Vim navigation
+// Default: true
+// Set to false for arrow key navigation
 const vimKeyNavigation = true;
 
 // Set selected entry colors
 const backgroundColor = '#373737';
 const textColor = 'white';
+
 // Set navigation keys with keycodes here: https://www.toptal.com/developers/keycode
 var nextKey = 'ArrowDown';
 var prevKey = 'ArrowUp';
@@ -47,6 +48,26 @@ const upvoteKey = 'KeyA';
 const downvoteKey = 'KeyZ';
 const replycommKey = 'KeyR';
 const saveKey = 'KeyS';
+const popupKey = 'KeyG';
+const contextKey = 'KeyQ'
+const smallerimgKey = 'Minus'
+const biggerimgKey = 'Equal'
+const userKey = 'KeyU'
+const editKey = 'KeyE'
+
+const modalCommentsKey = 'KeyC'
+const modalPostsKey = 'KeyP'
+const modalSubscribedKey = 'Digit1';
+const modalLocalKey = 'Digit2';
+const modalAllKey = 'Digit3';
+const modalSavedKey = 'KeyS';
+const modalFrontpageKey = 'KeyF';
+const modalProfileKey = 'KeyU';
+const modalInboxKey = 'KeyI';
+
+const escapeKey = 'Escape';
+var modalMode = 0
+console.log('modalMode: ' + modalMode);
 
 // Stop arrows from moving the page if not using Vim navigation
 window.addEventListener("keydown", function(e) {
@@ -65,6 +86,17 @@ const css = [
 "  color: " + textColor + ";",
 "}"
 ].join("\n");
+
+// dialog box
+var myDialog = document.createElement("dialog");
+document.body.appendChild(myDialog)
+var para = document.createElement("p");
+para.innerText = '--- Frontpage Sort ---\nP = posts\nC = comments\n1 = subscribed\n2 = local\n3 = all\n\n--- Everywhere Else ---\nS = saved\nF = frontpage\nU = profile\nI = inbox\n';
+myDialog.appendChild(para);
+let button = document.createElement("button");
+button.classList.add('CLOSEBUTTON1');
+button.innerHTML = 'Press ESC or G to Close';
+myDialog.appendChild(button);
 
 // Global variables
 let currentEntry;
@@ -94,8 +126,6 @@ if (typeof GM_addStyle !== "undefined") {
     }
 }
 const selectedClass = "selected";
-
-
 
 const targetNode = document.documentElement;
 const config = { childList: true, subtree: true };
@@ -152,89 +182,178 @@ function handleKeyPress(event) {
         return;
     }
 
-    switch (event.code) {
-        case nextKey:
-        case prevKey:
-            previousKey(event);
-            break;
-        case upvoteKey:
-            upVote();
-            break;
-        case downvoteKey:
-            downVote();
-            break;
-        case expandKey:
-            toggleExpand();
-            expand = isExpanded() ? true : false;
-            break;
-        case saveKey:
-            save();
-            break;
-        case openCommentsKey:
-            comments(event);
-            break;
-        case replycommKey:
-            if (window.location.pathname.includes("/post/")) {
+    switch (modalMode) {
+        case modalMode = 0:
+        switch (event.code) {
+            case nextKey:
+            case prevKey:
+                previousKey(event);
+                break;
+            case upvoteKey:
+                upVote();
+                break;
+            case downvoteKey:
+                downVote();
+                break;
+            case expandKey:
+                toggleExpand();
+                expand = isExpanded() ? true : false;
+                break;
+            case smallerimgKey:
+                imgresize(0);
+                break;
+            case biggerimgKey:
+                imgresize(1);
+                break;
+            case saveKey:
+                save();
+                break;
+            case editKey:
+                edit();
+                break;
+            case openCommentsKey:
+                comments(event);
+                break;
+            case popupKey:
+                gotodialog(1);
+                instanceanduser();
+                break;
+            case contextKey:
+                getcontext();
+                break;
+            case replycommKey:
+                if (window.location.pathname.includes("/post/")) {
                 // Allow Mac refresh with CMD+R
                 if (event.key !== 'Meta') {
-                reply(event);
+                    reply(event);
                 }
             } else {
                 community(event);
             }
             break;
-        case openLinkandcollapseKey:
-            if (window.location.pathname.includes("/post/")) {
-                toggleExpand();
-            } else {
-                const linkElement = currentEntry.querySelector(".col.flex-grow-1>p>a")
-                    if (linkElement) {
-                        if (event.shiftKey) {
-                            window.open(linkElement.href);
+            case userKey:
+                visituser();
+                break;
+            case openLinkandcollapseKey:
+                if (window.location.pathname.includes("/post/")) {
+                    toggleExpand();
+                } else {
+                    const linkElement = currentEntry.querySelector(".col.flex-grow-1>p>a")
+                        if (linkElement) {
+                            if (event.shiftKey) {
+                                window.open(linkElement.href);
+                            } else {
+                                linkElement.click();
+                            }
                         } else {
-                            linkElement.click();
+                            comments(event);
                         }
-                    } else {
-                        comments(event);
                     }
+                break;
+            case parentComment:{
+                let targetBlock;
+                if (currentEntry.classList.contains("ms-1")) {
+                    targetBlock = getPrevEntry(currentEntry);
                 }
-            break;
-        case parentComment:{
-            let targetBlock;
-            if (currentEntry.classList.contains("ms-1")) {
-                targetBlock = getPrevEntry(currentEntry);
-            }
-            else if (currentEntry.parentElement.parentElement.parentElement.nodeName == "LI") {
-                targetBlock = currentEntry.parentElement.parentElement.parentElement.getElementsByTagName("article")[0];
-            }
-            if (targetBlock) {
-                if (expand) collapseEntry();
-                selectEntry(targetBlock, true);
-                if (expand) expandEntry();
-            }}
-            break;
-        case nextPageKey:
-        case prevPageKey:{
-            const pageButtons = Array.from(document.querySelectorAll(".paginator>button"));
+                else if (currentEntry.parentElement.parentElement.parentElement.nodeName == "LI") {
+                    targetBlock = currentEntry.parentElement.parentElement.parentElement.getElementsByTagName("article")[0];
+                }
+                if (targetBlock) {
+                    if (expand) collapseEntry();
+                    selectEntry(targetBlock, true);
+                    if (expand) expandEntry();
+                }}
+                break;
+            case nextPageKey:
+            case prevPageKey:{
+                const pageButtons = Array.from(document.querySelectorAll(".paginator>button"));
 
-            if (pageButtons && (document.getElementsByClassName('paginator').length > 0)) {
-                const buttonText = event.code === nextPageKey ? "Next" : "Prev";
-                pageButtons.find(btn => btn.innerHTML === buttonText).click();
-            }
-            // Jump next block of comments
-            if (event.code === nextPageKey) {
+                if (pageButtons && (document.getElementsByClassName('paginator').length > 0)) {
+                    const buttonText = event.code === nextPageKey ? "Next" : "Prev";
+                    pageButtons.find(btn => btn.innerHTML === buttonText).click();
+                }
+                // Jump next block of comments
+                if (event.code === nextPageKey) {
                     commentBlock = getNextEntrySameLevel(currentEntry)
-            }
-            // Jump previous block of comments
-            if (event.code === prevPageKey) {
+                }
+                // Jump previous block of comments
+                if (event.code === prevPageKey) {
                     commentBlock = getPrevEntrySameLevel(currentEntry)
-            }
-
-            if (commentBlock) {
-                if (expand) collapseEntry();
-                selectEntry(commentBlock, true);
-                if (expand) expandEntry();
-            }}
+                }
+                if (commentBlock) {
+                    if (expand) collapseEntry();
+                    selectEntry(commentBlock, true);
+                    if (expand) expandEntry();
+                        }
+        }
+        }break;
+        case modalMode = 1:
+        switch (event.code) {
+            case escapeKey:
+                modalMode = 0;
+                console.log('modalMode: ' + modalMode);
+                break;
+            case popupKey:
+                gotodialog(0);
+                break;
+            case modalSubscribedKey:
+                var subelement = document.querySelectorAll('[title="Shows the communities you\'ve subscribed to"]')[0];
+                subelement.click();
+                gotodialog(0);
+                break;
+            case modalLocalKey:
+                var localelement = document.querySelectorAll('[title="Shows only local communities"]')[0];
+                localelement.click();
+                gotodialog(0);
+                break;
+            case modalAllKey:
+                var allelement = document.querySelectorAll('[title="Shows all communities, including federated ones"]')[0];
+                allelement.click();
+                gotodialog(0);
+                break;
+            case modalSavedKey:
+                if (window.location.pathname.includes("/u/")) {
+                    var savedelement = document.getElementsByClassName("btn btn-outline-secondary pointer")[3];
+                    if (savedelement) {
+                        savedelement.click();
+                        gotodialog(0);
+                    }
+                } else {
+                    instanceanduser(2);
+                }
+                break;
+            case modalFrontpageKey:
+                frontpage();
+                break;
+            case modalProfileKey:
+                var profileelement = document.querySelectorAll('[title="Profile"]')[0];
+                if (profileelement) {
+                    profileelement.click();
+                    gotodialog(0);
+                } else {
+                    instanceanduser(1);
+                }
+                break;
+            case modalInboxKey:
+                var notifelement = document.getElementsByClassName("nav-link d-inline-flex align-items-center d-md-inline-block")[2];
+                if (notifelement) {
+                    notifelement.click();
+                    gotodialog(0);
+                } else {
+                    console.log('Not logged in!');
+                }
+                break;
+            case modalCommentsKey:
+                var commentsbutton = document.getElementsByClassName("pointer btn btn-outline-secondary")[1];
+                commentsbutton.click();
+                gotodialog(0);
+                break;
+            case modalPostsKey:
+                var postsbutton = document.getElementsByClassName("pointer btn btn-outline-secondary")[0];
+                postsbutton.click();
+                gotodialog(0);
+                break;
+        }
     }
 }
 
@@ -367,6 +486,65 @@ function downVote() {
     }
 }
 
+function gotodialog(n) {
+
+    const closeButton = document.getElementsByClassName("CLOSEBUTTON1")[0];
+    closeButton.addEventListener("click", () => {
+        myDialog.close();
+        modalMode = 0;
+        console.log('modalMode: ' + modalMode);
+    });
+    if (n == 1) {
+        myDialog.showModal();
+        modalMode = 1;
+        console.log('modalMode: ' + modalMode);
+    }
+
+    if (n == 0) {
+        myDialog.close();
+        modalMode = 0;
+        console.log('modalMode: ' + modalMode);
+    }
+}
+
+function instanceanduser(n) {
+    var currentinstance = window.location.origin
+    var dropdownuser = document.getElementsByClassName("btn dropdown-toggle")[0];
+    var username = dropdownuser.textContent
+
+    if (n == 0) {
+        window.location.replace(currentinstance)
+    }
+    if (n == 1) {
+        if (username) {
+            var userlink = currentinstance+"/u/"+username
+            window.location.replace(userlink)
+        } else {
+            console.log('Not logged in!')
+            frontpage();
+        }
+    }
+    if (n == 2) {
+        if (username) {
+            var savedlink = currentinstance+"/u/"+username+"?page=1&sort=New&view=Saved"
+            window.location.replace(savedlink)
+        } else {
+            console.log('Not logged in!')
+            frontpage();
+        }
+    }
+}
+
+function frontpage() {
+    var homeelement = document.getElementsByClassName("d-flex align-items-center navbar-brand me-md-3 active")[0];
+    if (homeelement) {
+        homeelement.click();
+        gotodialog(0);
+    } else {
+        instanceanduser(0);
+    }
+}
+
 function reply(event) {
     const replyButton = currentEntry.querySelector("button[data-tippy-content='reply']");
 
@@ -386,6 +564,17 @@ function community(event) {
         }
 }
 
+function visituser() {
+    var userbutton = currentEntry.getElementsByClassName("person-listing d-inline-flex align-items-baseline text-info")[0]
+    var userHREF = currentEntry.getElementsByClassName("person-listing d-inline-flex align-items-baseline text-info")[0].href
+
+    if (event.shiftKey) {
+        window.open(userHREF)
+    } else {
+        userbutton.click();
+    }
+}
+
 function comments(event) {
     if (event.shiftKey) {
         window.open(
@@ -393,6 +582,54 @@ function comments(event) {
         );
     } else {
         currentEntry.querySelector("a.btn[title*='Comment']").click();
+    }
+}
+
+
+function getcontext() {
+    var contextbutton = currentEntry.querySelector('[title="Show context"]')
+    var contextHREF = currentEntry.querySelector('[title="Show context"]').href
+
+    if (event.shiftKey) {
+        window.open(contextHREF)
+    } else {
+        contextbutton.click();
+    }
+}
+
+var maxsize = 0
+console.log('maxsize '+maxsize)
+
+function imgresize(n) {
+    var expandedimg = currentEntry.getElementsByClassName("overflow-hidden pictrs-image img-fluid img-expanded slight-radius")[0];
+    var expandedheight = expandedimg.height
+    var expandedwidth = expandedimg.width
+    var expandedheightbefore = expandedheight
+    var expandedwidthbefore = expandedwidth
+
+    if (n == 0) {
+        expandedheight = expandedheight/1.15
+        expandedwidth = expandedwidth/1.15
+        expandedimg.style.height = expandedheight+'px'
+        expandedimg.style.width = expandedwidth+'px'
+        maxsize = 0
+        console.log('maxsize '+maxsize)
+    }
+
+    if (n == 1) {
+        expandedheight = expandedheight*1.15
+        expandedwidth = expandedwidth*1.15
+        expandedimg.style.width = expandedwidth+'px'
+        expandedimg.style.height = expandedheight+'px'
+
+        if (maxsize == 1) {
+            expandedimg.style.width = expandedwidthbefore+'px'
+            expandedimg.style.height = expandedheightbefore+'px'
+        }
+        if (expandedimg.width !== Math.round(expandedwidth) || expandedimg.height !== Math.round(expandedheight)) {
+            maxsize = 1
+            console.log('maxsize '+maxsize)
+        }
     }
 }
 
@@ -411,6 +648,17 @@ function save() {
         } else if (unsaveButton) {
             unsaveButton.click();
         }
+    }
+}
+
+function edit() {
+    var editButton = currentEntry.querySelector("button[aria-label='Edit']")
+    var moreButton = currentEntry.querySelector("button[aria-label='more']");
+
+    if (editButton) {
+        editButton.click();
+    } else {
+        moreButton.click();
     }
 }
 
@@ -434,6 +682,7 @@ function toggleExpand() {
                     currentEntry.offsetHeight - imgContainer.offsetHeight + 10
                 );
             }, true);
+            currentEntry.getElementsByClassName("offset-sm-3 my-2 d-none d-sm-block")[0].className = "my-2 d-none d-sm-block";
         }
     }
 


### PR DESCRIPTION
- pressing U on a post or comment will bring you to the poster/commenter's profile (shift+U for new tab)

- pressing E on your posts or comments will start editing them

- pressing minus or equals will shrink or grow expanded images

- pressing Q on a comment will go to the context (shift + q for new tab)

- pressing G will bring up a dialog, similar to the "Press a key to go to:" thing in RES. here's what it looks like:

![Flameshot_130](https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/75824710/4614f64d-06eb-47de-827a-f92e43a6b071)

- update keybind tables and replace images
