### PR TITLE
Add quick search

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,23 @@ Works on lemmy-ui and mlmym websites.
 | <kbd>=</kbd> = Grow Expanded Image                          | Q = Show context                                               |
 | G = Open Navigation Dialog                                  | G = Open Navigation Dialog                                     |
 | O = Open Options Page                                       | O = Open Options page                                          |
+| <kbd>.</kbd> = Open Quick Search                            | <kbd>.</kbd> = Open Quick Search                               |
 | C = View Comments (<kbd>⇧ Shift</kbd> + C to open in new tab) | P = Parent Comment                                           |
 | R = Go to community (<kbd>⇧ Shift</kbd>+ R to open in new tab) | R = Reply                                                   |
 | U = Go to poster's profile (<kbd>⇧ Shift</kbd> + U to open in new tab) | U = Go to commenter's profile (<kbd>⇧ Shift</kbd> + U to open in new tab) |
 | <kbd>⏎ Enter</kbd> = Visit Link (<kbd>⇧ Shift</kbd> + <kbd>⏎ Enter</kbd> to open in new tab) |                              |
 
-![linkpages](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/94743f5f-ccdd-490a-8e61-e57502931de6)
-![comments](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/6d4093ac-a6ce-4f56-9908-f5e49468b492)
+![linkpages](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/1a3bc7d4-564c-4054-9e26-be7edce811c8)
+![comments](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/b9b529d0-0736-4d91-9f8b-293e319a52c0)
 
 ### Options ('Ο'):
-<img width="200" alt="image" src="https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/8668731/5aa941d8-94ca-461f-bb10-7f1a590c1e1b">
+<img width="250" alt="image" src="https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/8668731/5aa941d8-94ca-461f-bb10-7f1a590c1e1b">
 
 ### Quicknav dialog ('G'):
-<img width="75" alt="image" src="https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/8668731/553df9c0-c5dd-423f-bc61-8d94f3465d1c">
+<img height="300" alt="image" src="https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/8668731/553df9c0-c5dd-423f-bc61-8d94f3465d1c">
+
+### Quick Search ('.'):
+![Flameshot_150](https://github.com/InfinibyteF4/Lemmy-keyboard-navigation/assets/75824710/5b429d02-540f-4bbb-926b-7d1de299d60c)
 
 ## Development: 
 #### For Chrome or Firefox extension

--- a/lemmy-keyboard-navigation-mlmym.user.js
+++ b/lemmy-keyboard-navigation-mlmym.user.js
@@ -86,7 +86,8 @@ function options(open) {
         m_saved: "KeyS",
         m_userpage: "KeyU",
         m_inbox: "KeyI",
-        m_options: "KeyO"
+        m_options: "KeyO",
+        s_search: "Period"
       },
       getSettingsFromLocalStorage()
     );
@@ -194,6 +195,9 @@ function options(open) {
     userOptions.m_options =
       document.getElementById("option_m_options").value;
 
+    userOptions.s_search =
+      document.getElementById("option_s_search").value;
+
     localStorage.setItem(optionsKey, JSON.stringify(userOptions));
     window.location.reload();
   }
@@ -263,6 +267,7 @@ const modalProfileKey = `${settings.m_userpage}`;
 const modalInboxKey = `${settings.m_inbox}`;
 const modalOptionsKey = `${settings.m_options}`;
 
+const searchKey = `${settings.s_search}`
 
 const escapeKey = 'Escape';
 let modalMode = 0;
@@ -308,6 +313,19 @@ let button = document.createElement("button");
 button.classList.add('CLOSEBUTTON1');
 button.innerHTML = `Press ESC or ${modalPopupKey} to Close`;
 myDialog.appendChild(button);
+
+//draw search bar
+const searchbar = document.createElement("div");
+searchbar.setAttribute("id", "lmSearch");
+searchbar.classList.add("lmsearch");
+searchbar.innerHTML = `
+<div id="searchForm">
+  Press Enter to search or ESC to close</br>
+  <input id="searchInput" type="text" placeholder="Search Lemmy">
+  <button id="searchSubmit">Search</button>
+  <button id="searchCancel">Close</button>
+<div>
+`;
 
 //draw settings page
 const odiv = document.createElement("div");
@@ -471,6 +489,13 @@ odiv.innerHTML = `
         <td><textarea id='option_m_options'>${settings.m_options}</textarea></td>
       </tr>
       <tr>
+          <td><h3><b>Rebind Searchbar Keys</b></h3></td><td><td/>
+      </tr>
+      <tr>
+        <td><b>Open search bar</b><br/>Default: Period</td>
+        <td><textarea id='option_s_search'>${settings.s_search}</textarea></td>
+      </tr>
+      <tr>
         <td><b>Save and close settings</b></td>
         <td><button id='LMsaveoptions'>Save and Close</button></td>
       </tr>
@@ -530,10 +555,26 @@ let styleString = `
   padding: 0.5%;
   margin-top:65px;
 }
+
+.lmsearch { /* from RES */
+  position: fixed;
+  top: 30px;
+  left: 50%;
+  margin-left: -275px;
+  z-index: 10800000;
+  width: 550px;
+  border: 3px solid ${backgroundColor};
+  border-radius: 10px;
+  padding: 10px;
+  background-color: #333;
+  color: #ccc;
+}
 `;
 document.head.appendChild(document.createElement("style")).innerHTML = styleString;
 document.body.appendChild(odiv); //options
 try { document.body.appendChild(LMbutton); } catch {};
+document.body.appendChild(searchbar); //cmdline
+document.getElementById('lmSearch').style.display = 'none';
 
 document.getElementById("LMsaveoptions").addEventListener("click", (e) => {
   e.preventDefault();
@@ -553,6 +594,21 @@ try {
     call();
   });
 } catch {}
+document.getElementById("searchSubmit").addEventListener("click", (e) => {
+  goToSearch("search");
+});
+document.getElementById("searchCancel").addEventListener("click", (e) => {
+  goToSearch("close");
+});
+document.getElementById("searchInput").addEventListener('keydown', function onEvent(event) {
+    if (event.key === "Enter") {
+        goToSearch("search");
+    }
+    if (event.key === "Escape") {
+        goToSearch("close");
+    }
+});
+
 // Global variables
 let currentEntry;
 let commentBlock;
@@ -672,6 +728,9 @@ function handleKeyPress(event) {
         case openCommentsKey:
           comments(event);
           break;
+        case searchKey:
+          goToSearch("open");
+        break;
         case modalPopupKey:
           goToDialog("open");
           break;
@@ -835,6 +894,13 @@ function handleKeyPress(event) {
           case modalOptionsKey:
           options("open");
           goToDialog("close");
+          break;
+      }
+      break;
+    case modalMode = 2:
+      switch (event.code) {
+        case escapeKey:
+          goToSearch("close");
           break;
       }
   }
@@ -1070,6 +1136,28 @@ function goToDialog(n) {
     myDialog.close();
     modalMode = 0;
     console.log(`modalMode: ${modalMode}`);
+  }
+}
+
+let searchQuery;
+function goToSearch(n) {
+  if (n === "open") {
+    document.getElementById('lmSearch').style.display = 'block';
+    document.getElementById('searchInput').focus();
+    setTimeout(function() {
+      document.getElementById('searchInput').value = ''; // this is to get rid of the '.' in the search box
+    }, 1);
+    modalMode = 2;
+    console.log(`modalMode: ${modalMode}`);
+  }
+  if (n === "close") {
+    document.getElementById('lmSearch').style.display = 'none';
+    modalMode = 0;
+    console.log(`modalMode: ${modalMode}`);
+  }
+  if (n === "search") {
+    searchQuery = document.getElementById("searchInput").value;
+    window.location = `${window.location.origin}/search?q=${searchQuery}&searchtype=Posts&sort=TopAll&listingType=All`;
   }
 }
 

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -77,7 +77,8 @@ function options(open) {
         m_saved: "KeyS",
         m_userpage: "KeyU",
         m_inbox: "KeyI",
-        m_options: "KeyO"
+        m_options: "KeyO",
+        s_search: "Period"
       },
       getSettingsFromLocalStorage()
     );
@@ -185,6 +186,9 @@ function options(open) {
     userOptions.m_options =
       document.getElementById("option_m_options").value;
 
+    userOptions.s_search =
+      document.getElementById("option_s_search").value;
+
     localStorage.setItem(optionsKey, JSON.stringify(userOptions));
     window.location.reload();
   }
@@ -255,6 +259,7 @@ const modalProfileKey = `${settings.m_userpage}`;
 const modalInboxKey = `${settings.m_inbox}`;
 const modalOptionsKey = `${settings.m_options}`;
 
+const searchKey = `${settings.s_search}`
 
 const escapeKey = 'Escape';
 let modalMode = 0;
@@ -300,6 +305,19 @@ let button = document.createElement("button");
 button.classList.add('CLOSEBUTTON1');
 button.innerHTML = `Press ESC or ${modalPopupKey} to Close`;
 myDialog.appendChild(button);
+
+//draw search bar
+const searchbar = document.createElement("div");
+searchbar.setAttribute("id", "lkSearch");
+searchbar.classList.add("lksearch");
+searchbar.innerHTML = `
+<div id="searchForm">
+  Press Enter to search or ESC to close</br>
+  <input id="searchInput" type="text" placeholder="Search Lemmy">
+  <button id="searchSubmit">Search</button>
+  <button id="searchCancel">Close</button>
+<div>
+`;
 
 //draw settings page
 const odiv = document.createElement("div");
@@ -466,6 +484,13 @@ odiv.innerHTML = `
         <td><textarea id='option_m_options'>${settings.m_options}</textarea></td>
       </tr>
       <tr>
+          <td><h3><b>Rebind Searchbar Keys</b></h3></td><td><td/>
+      </tr>
+      <tr>
+        <td><b>Open search bar</b><br/>Default: Period</td>
+        <td><textarea id='option_s_search'>${settings.s_search}</textarea></td>
+      </tr>
+      <tr>
         <td><b>Save and close settings</b></td>
         <td><button id='LKsaveoptions'>Save and Close</button></td>
       </tr>
@@ -502,9 +527,25 @@ let styleString = `
   padding: 0.5%;
   margin-top:35px;
 }
+
+.lksearch { /* from RES */
+  position: fixed;
+  top: 30px;
+  left: 50%;
+  margin-left: -275px;
+  z-index: 10800000;
+  width: 550px;
+  border: 3px solid ${backgroundColor};
+  border-radius: 10px;
+  padding: 10px;
+  background-color: #333;
+  color: #ccc;
+}
 `;
 document.head.appendChild(document.createElement("style")).innerHTML = styleString;
 document.body.appendChild(odiv); //options
+document.body.appendChild(searchbar); //cmdline
+document.getElementById('lkSearch').style.display = 'none';
 
 document.getElementById("LKsaveoptions").addEventListener("click", (e) => {
   e.preventDefault();
@@ -518,6 +559,20 @@ document.getElementById("LKresetoptions").addEventListener("click", (e) => {
   e.preventDefault();
   localStorage.clear();
   window.location.reload();
+});
+document.getElementById("searchSubmit").addEventListener("click", (e) => {
+  goToSearch("search");
+});
+document.getElementById("searchCancel").addEventListener("click", (e) => {
+  goToSearch("close");
+});
+document.getElementById("searchInput").addEventListener('keydown', function onEvent(event) {
+    if (event.key === "Enter") {
+        goToSearch("search");
+    }
+    if (event.key === "Escape") {
+        goToSearch("close");
+    }
 });
 
 // Global variables
@@ -656,6 +711,9 @@ function handleKeyPress(event) {
           break;
         case openCommentsKey:
           comments(event);
+          break;
+        case searchKey:
+          goToSearch("open");
           break;
         case modalPopupKey:
           dialogUpdate();
@@ -847,6 +905,13 @@ function handleKeyPress(event) {
         case modalOptionsKey:
           options("open");
           goToDialog("close");
+          break;
+      }
+      break;
+    case modalMode = 2:
+      switch (event.code) {
+        case escapeKey:
+          goToSearch("close");
           break;
       }
   }
@@ -1132,6 +1197,28 @@ function goToDialog(n) {
     myDialog.close();
     modalMode = 0;
     console.log(`modalMode: ${modalMode}`);
+  }
+}
+
+let searchQuery;
+function goToSearch(n) {
+  if (n === "open") {
+    document.getElementById('lkSearch').style.display = 'block';
+    document.getElementById('searchInput').focus();
+    setTimeout(function() {
+      document.getElementById('searchInput').value = ''; // this is to get rid of the '.' in the search box
+    }, 1);
+    modalMode = 2;
+    console.log(`modalMode: ${modalMode}`);
+  }
+  if (n === "close") {
+    document.getElementById('lkSearch').style.display = 'none';
+    modalMode = 0;
+    console.log(`modalMode: ${modalMode}`);
+  }
+  if (n === "search") {
+    searchQuery = document.getElementById("searchInput").value;
+    window.location = `${window.location.origin}/search?q=${searchQuery}&type=All&listingType=All&page=1&sort=TopAll`;
   }
 }
 

--- a/main.user.js
+++ b/main.user.js
@@ -8,8 +8,8 @@
 // @author        aglidden
 // @author        howdy-tsc
 // @license       GPL3
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=6b891c5787cb66bf049f7784d5a94ae0
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=03c514429d82fa93c6cdd9797c6267e5
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=48cf15e357f6a179a01e759d47e79c37
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=ee958dafe64f1fa9207afdbb485ae337
 // @icon          https://raw.githubusercontent.com/vmavromatis/Lemmy-keyboard-navigation/main/icon.png?inline=true
 // @homepageURL   https://github.com/vmavromatis/Lemmy-keyboard-navigation
 // @namespace     https://github.com/vmavromatis/Lemmy-keyboard-navigation


### PR DESCRIPTION
- Pressing period will bring up quick search by default, which looks like this:
![Flameshot_150](https://github.com/vmavromatis/Lemmy-keyboard-navigation/assets/75824710/38c4668e-7d81-4c5a-99d8-f7847a77e70b)
(like RES command line but search-only for now)

- Update keybind tables and images
- Add a screenshot of the quick search to the README