### PR TITLE
fix Lemmy 0.19 next/prev page keybinds

### DIFF
--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -839,10 +839,20 @@ function handleKeyPress(event) {
           const pageButtons = Array.from(document.querySelectorAll(".paginator>button"));
 
           if (pageButtons && (document.getElementsByClassName('paginator').length > 0)) {
-            if (event.code === nextPageKey) {
-              document.querySelectorAll(".paginator>.btn.btn-secondary")[1].click(); //next
-            } else {
-              document.querySelectorAll(".paginator>.btn.btn-secondary")[0].click(); //prev
+            if (pageButtons.length === 2) {
+              if (event.code === nextPageKey) {
+                document.querySelectorAll(".paginator>.btn.btn-secondary")[1].click(); //next
+              } else {
+                document.querySelectorAll(".paginator>.btn.btn-secondary")[0].click(); //prev
+              }
+            } else { // Lemmy 0.19 (no back button)
+              if (event.code === nextPageKey) {
+                document.querySelectorAll(".paginator>.btn.btn-secondary")[0].click(); //next
+              } else {
+                if (window.location != window.origin+window.location.pathname) {
+                  history.back(); //prev
+                }
+              }
             }
           }
           // Jump next block of comments

--- a/main.user.js
+++ b/main.user.js
@@ -8,7 +8,7 @@
 // @author        aglidden
 // @author        howdy-tsc
 // @license       GPL3
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=2af361a2024d5caa95940d124885b9c9
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=fd1aa7b186a174517d2d68226ef1b348
 // @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=0e5c168978a51db42178fdee2456c41d
 // @icon          https://raw.githubusercontent.com/vmavromatis/Lemmy-keyboard-navigation/main/icon.png?inline=true
 // @homepageURL   https://github.com/vmavromatis/Lemmy-keyboard-navigation


### PR DESCRIPTION
https://github.com/vmavromatis/Lemmy-keyboard-navigation/issues/42

- Preserves the previous page keybind by using history.back()