### PR TITLE
Automatically set dark/light defaults

### DIFF
--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -39,7 +39,6 @@ function checkedIfTrue(val) {
   return val ? "checked" : "";
 }
 
-
 function options(open) {
   const odiv = document.getElementById("lkOptions");
   let userOptions = {};
@@ -56,7 +55,8 @@ function options(open) {
         smoothScroll: false,
         scrollPosition: "middle",
         expandOption: "both",
-        backgroundHex: "",
+        backgroundHexDark: "#373737",
+        backgroundHexLight: "#dadbdd",
         kb_expand: "KeyX",
         kb_comments: "KeyC",
         kb_openLink: "Enter",
@@ -121,14 +121,11 @@ function options(open) {
     userOptions.expandOption =
     document.getElementById("option_expandOption").value;
 
-    //if empty set to light/dark defaults, else set to user selection
-    if (document.getElementById("option_backgroundHex").value == "" && document.getElementById("app").getAttribute("data-bs-theme")==="light"){
-    userOptions.backgroundHex = "#FFDEAD"
-    }else if (document.getElementById("option_backgroundHex").value == "" && document.getElementById("app").getAttribute("data-bs-theme")==="dark"){
-    userOptions.backgroundHex = "#373737"
-    }else{
-    userOptions.backgroundHex =
-      document.getElementById("option_backgroundHex").value;}
+    userOptions.backgroundHexDark =
+      document.getElementById("option_backgroundHexDark").value;
+
+    userOptions.backgroundHexLight =
+      document.getElementById("option_backgroundHexLight").value;
 
     //keybinds
     userOptions.kb_expand =
@@ -228,12 +225,17 @@ let autoNext = checkedIfTrue(settings.autoNext);
 let openNewTab = checkedIfTrue(settings.openNewTab);
 let pageOffset = window.innerHeight * settings.pageOffset / 100;
 let scrollPosition = settings.scrollPosition;
-let backgroundHex = settings.backgroundHex;
+let backgroundHexDark = settings.backgroundHexDark;
+let backgroundHexLight = settings.backgroundHexLight;
 let expandOption = settings.expandOption;
 
 // Set selected entry colors
-const backgroundColor = `${backgroundHex}`;
-const textColor = 'white';
+var backgroundColor = `${backgroundHexDark}`;
+var textColor = 'white';
+if (document.getElementById("app").getAttribute("data-bs-theme") === "light") {
+  backgroundColor = `${backgroundHexLight}`;
+  textColor = 'black';
+}
 
 // Set navigation keys with keycodes here: https://www.toptal.com/developers/keycode
 let nextKey = 'ArrowDown';
@@ -407,8 +409,12 @@ odiv.innerHTML = `
             </select></td>
       </tr>
       <tr>
-        <td><b>Selected Hex Code</b><br/>The background color of selected posts/comments.<br/>Leave empty for default</td>
-        <td><textarea id='option_backgroundHex'>${settings.backgroundHex}</textarea></td>
+        <td><b>Selected Hex Code (Dark Mode)</b><br/>The background color of selected posts/comments.<br/>Default: #373737</td>
+        <td><textarea id='option_backgroundHexDark'>${settings.backgroundHexDark}</textarea></td>
+      </tr>
+      <tr>
+        <td><b>Selected Hex Code (Light Mode)</b><br/>The background color of selected posts/comments.<br/>Default: #dadbdd</td>
+        <td><textarea id='option_backgroundHexLight'>${settings.backgroundHexLight}</textarea></td>
       </tr>
       <tr>
           <td><h3><b>Rebind Keys</b></h3>Set keybinds with keycodes here:<br/><a href='https://www.toptal.com/developers/keycode'>https://www.toptal.com/developers/keycode</a></td><td><td/>
@@ -1686,3 +1692,4 @@ function scrollPage(y) {
 }
 
 }
+ 

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -39,6 +39,7 @@ function checkedIfTrue(val) {
   return val ? "checked" : "";
 }
 
+
 function options(open) {
   const odiv = document.getElementById("lkOptions");
   let userOptions = {};
@@ -55,7 +56,7 @@ function options(open) {
         smoothScroll: false,
         scrollPosition: "middle",
         expandOption: "both",
-        backgroundHex: "#373737",
+        backgroundHex: "",
         kb_expand: "KeyX",
         kb_comments: "KeyC",
         kb_openLink: "Enter",
@@ -120,8 +121,15 @@ function options(open) {
     userOptions.expandOption =
     document.getElementById("option_expandOption").value;
 
+    //if empty set to light/dark defaults, else set to user selection
+    if (document.getElementById("option_backgroundHex").value == "" && document.getElementById("app").getAttribute("data-bs-theme")==="light"){
+    userOptions.backgroundHex = "#FFDEAD"
+    }else if (document.getElementById("option_backgroundHex").value == "" && document.getElementById("app").getAttribute("data-bs-theme")==="dark"){
+    userOptions.backgroundHex = "#373737"
+    }else{
     userOptions.backgroundHex =
-      document.getElementById("option_backgroundHex").value;
+      document.getElementById("option_backgroundHex").value;}
+
     //keybinds
     userOptions.kb_expand =
       document.getElementById("option_kb_expand").value;
@@ -399,7 +407,7 @@ odiv.innerHTML = `
             </select></td>
       </tr>
       <tr>
-        <td><b>Selected Hex Code</b><br/>The background color of selected posts/comments.<br/>Default: #373737</td>
+        <td><b>Selected Hex Code</b><br/>The background color of selected posts/comments.<br/>Leave empty for default</td>
         <td><textarea id='option_backgroundHex'>${settings.backgroundHex}</textarea></td>
       </tr>
       <tr>


### PR DESCRIPTION
Fix #49

Leaving the color field empty sets a default color which differs depending if light or dark theme is selected