### PR TITLE
fix selection going to next comment when expanding

### DIFF
--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -1823,7 +1823,7 @@ function toggleExpand(n = true) {
   }
 
   if (commentExpandButton) {
-    if (autoNextCollapse && n) {
+    if (autoNextCollapse && n && isExpandedComment()) {
       commentExpandButton.click();
       selectEntry(getNextEntry(currentEntry), true);
     } else {

--- a/main.user.js
+++ b/main.user.js
@@ -8,7 +8,7 @@
 // @author        aglidden
 // @author        howdy-tsc
 // @license       GPL3
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=04c5bef05b3b9d6e0b0032c73133c781
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=8c7c5e51f31290b8a48f4169d553d87b
 // @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=53de470a0975b0b608377fd55c649530
 // @icon          https://raw.githubusercontent.com/vmavromatis/Lemmy-keyboard-navigation/main/icon.png?inline=true
 // @homepageURL   https://github.com/vmavromatis/Lemmy-keyboard-navigation


### PR DESCRIPTION
https://github.com/vmavromatis/Lemmy-keyboard-navigation/issues/75
- fix selection going to the next entry when expanding comments with auto next on collapse enabled