### PR TITLE
add rgba values for selection colors instead of hex codes

### DIFF
--- a/lemmy-keyboard-navigation-mlmym.user.js
+++ b/lemmy-keyboard-navigation-mlmym.user.js
@@ -26,13 +26,6 @@ console.log(`This userscript doesn't currently work with endless scrolling/auto 
 localStorage.setItem('endlessScrolling', false);
 localStorage.setItem('autoLoad', false);
 
-// set background color based on if dark mode is on or not
-let background;
-if (document.getElementsByClassName("dark").length >= 1) {
-  background = '#303030';
-} else {
-  background = '#f0f3fc';
-}
 // settings page (this is from lemmyTools)
 const optionsKey = "mlmym-keyboard-navigation-Options";
 
@@ -66,8 +59,8 @@ function options(open) {
         openNewTab: false,
         smoothScroll: false,
         scrollPosition: "middle",
-        backgroundHexDark: "#303030",
-        backgroundHexLight: "#f0f3fc",
+        backgroundRGBA: "rgba(141, 141, 141, 0.1)",
+        kb_fixButton: "KeyW",
         kb_prevPage: "KeyH",
         kb_nextPage: "KeyL",
         kb_prevKey: "KeyK",
@@ -142,12 +135,12 @@ function options(open) {
     userOptions.scrollPosition =
       document.getElementById("option_scrollPosition").value;
 
-    userOptions.backgroundHexDark =
-      document.getElementById("option_backgroundHexDark").value;
-
-    userOptions.backgroundHexLight =
-      document.getElementById("option_backgroundHexLight").value;
+    userOptions.backgroundRGBA =
+      document.getElementById("option_backgroundRGBA").value;
     //keybinds
+    userOptions.kb_fixButton =
+      document.getElementById("option_kb_fixButton").value;
+
     userOptions.kb_prevPage =
       document.getElementById("option_kb_prevPage").value;
 
@@ -259,16 +252,13 @@ let expandNext = checkedIfTrue(settings.expandNext);
 let openNewTab = checkedIfTrue(settings.openNewTab);
 let pageOffset = window.innerHeight * settings.pageOffset / 100;
 let scrollPosition = settings.scrollPosition;
-let backgroundHexDark = settings.backgroundHexDark;
-let backgroundHexLight = settings.backgroundHexLight;
+let backgroundRGBA = settings.backgroundRGBA;
 let mlmymFixButton = checkedIfTrue(settings.mlmymFixButton);
 
 // Set selected entry colors
-var backgroundColor = `${backgroundHexLight}`;
-if (document.getElementsByClassName("dark").length >= 1) {
-  backgroundColor = `${backgroundHexDark}`;
-}
+var backgroundColor = `${backgroundRGBA}`;
 
+const fixKey = `${settings.kb_fixButton}`
 const nextPageKey = `${settings.kb_nextPage}`;
 const prevPageKey = `${settings.kb_prevPage}`;
 const nextKey = `${settings.kb_nextKey}`;
@@ -394,7 +384,7 @@ odiv.innerHTML = `
     </tr>
     <tbody>
       <tr>
-        <td><b>Enable mlmym fix selections button</b><br/>Click this button if you can't select a post or comment.<br/>Uncheck to hide this button.</td>
+        <td><b>Enable mlmym fix selections button</b><br/>Click this button if you can't select a post or comment.<br/>Uncheck to hide this button.<br/>A keybind is also available.</td>
         <td><input type='checkbox' id='option_mlmymFixButton' ${mlmymFixButton} /></td>
       </tr>
       <tr>
@@ -439,17 +429,17 @@ odiv.innerHTML = `
             </select></td>
       </tr>
       <tr>
-        <td><b>Selected Hex Code (Dark Mode)</b><br/>The background color of selected posts/comments.<br/>Default: #303030</td>
-        <td><textarea id='option_backgroundHexDark'>${settings.backgroundHexDark}</textarea></td>
-      </tr>
-      <tr>
-        <td><b>Selected Hex Code (Light Mode)</b><br/>The background color of selected posts/comments.<br/>Default: #f0f3fc</td>
-        <td><textarea id='option_backgroundHexLight'>${settings.backgroundHexLight}</textarea></td>
+        <td><b>Selected Background Color</b><br/>The background color of selected posts/comments.<br/>The first three values are red, green, and blue.<br/>The last value is alpha, which is transparency.<br/>Default: rgba(141, 141, 141, 0.1)</br></br></td>
+        <td><textarea id='option_backgroundRGBA'>${settings.backgroundRGBA}</textarea></td>
       </tr>
       <tr>
           <td><h3><b>Rebind Keys</b></h3>Set keybinds with keycodes here:<br/><a href='https://www.toptal.com/developers/keycode'>https://www.toptal.com/developers/keycode</a></td><td><td/>
       </tr>
       <tr>
+      <tr>
+        <td><b>Mlmym Fix Keybind</b><br/>Press this key if you can't select a post or comment.<br/>Default: KeyW</td>
+        <td><textarea id='option_kb_fixButton'>${settings.kb_fixButton}</textarea></td>
+      </tr>
       <tr>
         <td><b>Next Page Key</b><br/>Go to the next page.<br/>Default: KeyL</td>
         <td><textarea id='option_kb_nextPage'>${settings.kb_nextPage}</textarea></td>
@@ -628,7 +618,8 @@ let styleString = `
   z-index: 1000;
   padding: 0.5%;
   margin-top:35px;
-  background-color: ${background};
+  background-color: #bababa;
+  color: #000000;
 }
 
 .lmfix {
@@ -789,6 +780,9 @@ function handleKeyPress(event) {
   switch (modalMode) {
     case modalMode = 0:
       switch (event.code) {
+        case fixKey:
+          call();
+          break;
         case nextKey:
         case prevKey:
           previousKey(event);

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -58,9 +58,7 @@ function options(open) {
         smoothScroll: false,
         scrollPosition: "middle",
         expandOption: "both",
-        colorOption: "auto",
-        backgroundHexDark: "#373737",
-        backgroundHexLight: "#dadbdd",
+        backgroundRGBA: "rgba(141, 141, 141, 0.1)",
         kb_prevPage: "KeyH",
         kb_nextPage: "KeyL",
         kb_prevKey: "KeyK",
@@ -135,14 +133,8 @@ function options(open) {
     userOptions.expandOption =
     document.getElementById("option_expandOption").value;
 
-    userOptions.colorOption =
-      document.getElementById("option_colorOption").value;
-
-    userOptions.backgroundHexDark =
-      document.getElementById("option_backgroundHexDark").value;
-
-    userOptions.backgroundHexLight =
-      document.getElementById("option_backgroundHexLight").value;
+    userOptions.backgroundRGBA =
+      document.getElementById("option_backgroundRGBA").value;
 
     //keybinds
     userOptions.kb_prevPage =
@@ -256,9 +248,7 @@ let autoPage = checkedIfTrue(settings.autoPage);
 let openNewTab = checkedIfTrue(settings.openNewTab);
 let pageOffset = window.innerHeight * settings.pageOffset / 100;
 let scrollPosition = settings.scrollPosition;
-let colorOption = settings.colorOption;
-let backgroundHexDark = settings.backgroundHexDark;
-let backgroundHexLight = settings.backgroundHexLight;
+let backgroundRGBA = settings.backgroundRGBA;
 let expandOption = settings.expandOption;
 
 let majorversion;
@@ -269,16 +259,7 @@ try {
 }
 
 // Set selected entry colors
-var backgroundColor = `${backgroundHexDark}`;
-var textColor = 'white';
-if (document.getElementById("app").getAttribute("data-bs-theme") === "light" || colorOption === "light") {
-  backgroundColor = `${backgroundHexLight}`;
-  textColor = 'black';
-}
-if (colorOption === "dark") {
-  backgroundColor = `${backgroundHexDark}`;
-  textColor = 'white';
-}
+var backgroundColor = `${backgroundRGBA}`;
 
 const nextPageKey = `${settings.kb_nextPage}`;
 const prevPageKey = `${settings.kb_prevPage}`;
@@ -342,8 +323,8 @@ document.documentElement.style = "scroll-behavior: auto";
 const css = `
   .selected {
     background-color: ${backgroundColor} !important;
-    color: ${textColor};
-    }`;
+  }
+`;
 
 // add an options button in the nav bar
 navbarLinks();
@@ -452,21 +433,8 @@ odiv.innerHTML = `
             </select></td>
       </tr>
       <tr>
-        <td><b>Selection Dark/Light Mode</b><br/>auto: automatically detect light/dark mode<br/>dark: set selections to dark mode<br/>light: set selections to light mode</br></br></td>
-        <td><select id="option_colorOption">
-            <option value='${settings.colorOption}'>${settings.colorOption}</option>
-            <option value='auto'>auto</option>
-            <option value='dark'>dark</option>
-            <option value='light'>light</option>
-            </select></td>
-      </tr>
-      <tr>
-        <td><b>Selected Hex Code (Dark Mode)</b><br/>The background color of selected posts/comments.<br/>Default: #373737</br></br></td>
-        <td><textarea id='option_backgroundHexDark'>${settings.backgroundHexDark}</textarea></td>
-      </tr>
-      <tr>
-        <td><b>Selected Hex Code (Light Mode)</b><br/>The background color of selected posts/comments.<br/>Default: #dadbdd</br></br></td>
-        <td><textarea id='option_backgroundHexLight'>${settings.backgroundHexLight}</textarea></td>
+        <td><b>Selected Background Color</b><br/>The background color of selected posts/comments.<br/>The first three values are red, green, and blue.<br/>The last value is alpha, which is transparency.<br/>Default: rgba(141, 141, 141, 0.1)</br></br></td>
+        <td><textarea id='option_backgroundRGBA'>${settings.backgroundRGBA}</textarea></td>
       </tr>
       <tr>
           <td><h3><b>Rebind Keys</b></h3>Set keybinds with keycodes here:<br/><a href='https://www.toptal.com/developers/keycode'>https://www.toptal.com/developers/keycode</a></td><td><td/>

--- a/main.user.js
+++ b/main.user.js
@@ -8,8 +8,8 @@
 // @author        aglidden
 // @author        howdy-tsc
 // @license       GPL3
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=8c7c5e51f31290b8a48f4169d553d87b
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=53de470a0975b0b608377fd55c649530
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=65e3ae751ca9545ea23a792cbd74556f
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=d734a2d60f5834367a90996fde4f6631
 // @icon          https://raw.githubusercontent.com/vmavromatis/Lemmy-keyboard-navigation/main/icon.png?inline=true
 // @homepageURL   https://github.com/vmavromatis/Lemmy-keyboard-navigation
 // @namespace     https://github.com/vmavromatis/Lemmy-keyboard-navigation


### PR DESCRIPTION
https://github.com/vmavromatis/Lemmy-keyboard-navigation/issues/55
https://github.com/vmavromatis/Lemmy-keyboard-navigation/issues/65

- add @CouldBeThis's idea to use RGBA colors instead of hex codes for selection colors that will work on both light and dark mode
- add fix keybind for mlmym