### PR TITLE
Fix arrow keys in text boxes when Enable Arrow Key Scrolling is disabled

### DIFF
--- a/lemmy-keyboard-navigation-mlmym.user.js
+++ b/lemmy-keyboard-navigation-mlmym.user.js
@@ -311,7 +311,10 @@ console.log(`modalMode: ${modalMode}`);
 
 // Stop arrows from moving the page if arrow key scrolling is disabled
 window.addEventListener("keydown", function(e) {
-  if (["ArrowUp", "ArrowDown"].indexOf(e.code) > -1 && !enableArrowKeyScrolling) {
+  if (!enableArrowKeyScrolling
+    && ["ArrowUp", "ArrowDown"].indexOf(e.code) > -1
+    && ["TEXTAREA", "INPUT"].indexOf(e.target.tagName) === -1
+  ) {
     e.preventDefault();
   }
 }, false);

--- a/lemmy-keyboard-navigation-mlmym.user.js
+++ b/lemmy-keyboard-navigation-mlmym.user.js
@@ -2,7 +2,7 @@
 // @name          mlmym-keyboard-navigation
 // @match         https://*/*
 // @grant         none
-// @version       2.6
+// @version       2.9
 // @author        vmavromatis
 // @author        howdy@thesimplecorner.org
 // @author        InfinibyteF4

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -3,7 +3,7 @@
 // @match         https://*/*
 // @include       https://*/*
 // @grant         none
-// @version       2.6
+// @version       2.9
 // @author        vmavromatis
 // @author        InfinibyteF4
 // @author        aglidden

--- a/lemmy-keyboard-navigation.user.js
+++ b/lemmy-keyboard-navigation.user.js
@@ -311,7 +311,10 @@ console.log(`modalMode: ${modalMode}`);
 
 // Stop arrows from moving the page if arrow key scrolling is disabled
 window.addEventListener("keydown", function(e) {
-  if (["ArrowUp", "ArrowDown"].indexOf(e.code) > -1 && !enableArrowKeyScrolling) {
+  if (!enableArrowKeyScrolling
+    && ["ArrowUp", "ArrowDown"].indexOf(e.code) > -1
+    && ["TEXTAREA", "INPUT"].indexOf(e.target.tagName) === -1
+  ) {
     e.preventDefault();
   }
 }, false);

--- a/main.user.js
+++ b/main.user.js
@@ -8,8 +8,8 @@
 // @author        aglidden
 // @author        howdy-tsc
 // @license       GPL3
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=65e3ae751ca9545ea23a792cbd74556f
-// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=d734a2d60f5834367a90996fde4f6631
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation.user.js#md5=db797ecd6942303b080dbf26c1c4d345
+// @require       https://github.com/vmavromatis/Lemmy-keyboard-navigation/raw/main/lemmy-keyboard-navigation-mlmym.user.js#md5=e661224913a2f8fa46a4e06275535043
 // @icon          https://raw.githubusercontent.com/vmavromatis/Lemmy-keyboard-navigation/main/icon.png?inline=true
 // @homepageURL   https://github.com/vmavromatis/Lemmy-keyboard-navigation
 // @namespace     https://github.com/vmavromatis/Lemmy-keyboard-navigation

--- a/main.user.js
+++ b/main.user.js
@@ -2,7 +2,7 @@
 // @name          lemmy-keyboard-navigation
 // @match         https://*/*
 // @grant         none
-// @version       2.8
+// @version       2.9
 // @author        vmavromatis
 // @author        InfinibyteF4
 // @author        aglidden


### PR DESCRIPTION
Currently, turning off Enable Arrow Key Scrolling also disables arrow keys from navigating inside of a text area. This PR addresses the issue by checking if the currently selected area is a text box before disabling default behaviour.

Tested using Violentmonkey in lemmy-ui, but not in mlmym.